### PR TITLE
Bump bson_ext version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'rails', '3.0.0'
 
 # Bundle gems needed for Mongoid
 gem "mongoid", "2.0.0.beta.19"
-gem "bson_ext", "1.1"
+gem "bson_ext", "1.1.1"
 
 # Bundle gem needed for Devise
 gem "devise", "1.1.3"

--- a/template.rb
+++ b/template.rb
@@ -96,7 +96,7 @@ puts "setting up Gemfile for Mongoid..."
 gsub_file 'Gemfile', /gem \'sqlite3-ruby/, '# gem \'sqlite3-ruby'
 append_file 'Gemfile', "\n# Bundle gems needed for Mongoid\n"
 gem "mongoid", "2.0.0.beta.19"
-gem 'bson_ext', '1.1'
+gem 'bson_ext', '1.1.1'
 
 puts "installing Mongoid gems (takes a few minutes!)..."
 run 'bundle install'


### PR DESCRIPTION
Using 1.1 was causing a crash when attempting to generate the application using the template.  Bumping it to 1.1.1 made everything run smoothly.
